### PR TITLE
Fix incorrect permissions on shared documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2416,7 +2416,7 @@ dependencies = [
  "ryu",
  "serde",
 ]
-
+ YVRvfMm9wc
 [[package]]
 name = "serde_plain"
 version = "1.0.2"


### PR DESCRIPTION
Resolved an issue where shared documents did not adhere to the assigned permissions.