### PR TITLE
Fix rendering issues in summary charts with sparse data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -952,7 +952,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
- "libc", NF0eZ8u4hF
+ "libc",
  "windows-sys 0.52.0",
 ]
 


### PR DESCRIPTION
Addressed a problem where summary charts failed to display sparse datasets correctly.