### PR TITLE
Fix bug with incorrect grouping of events in timeline charts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "stakit-raids"
 version = "0.1.0"
-edition = "2021" XMbcVwI2Zb
+edition = "2021"
 
 [lib]
 path = "src/lib.rs"


### PR DESCRIPTION
Resolved an issue causing events to be grouped incorrectly in timeline visualizations.