### PR TITLE
Fix bug with API key regeneration not invalidating old keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,5 @@ uuid = { version = "1.4.0", features = ["serde", "v4"] }
 chrono = { version = "0.4.26", features = ["serde"] }
 tokio = { version = "1.29.1", features = ["full"] }
 bigdecimal = { version = "0.3.0", features = ["serde"] }
-serenity = { version = "0.12.0", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] } NAFgraKJRc
+serenity = { version = "0.12.0", default-features = false, features = ["client", "gateway", "rustls_backend", "model"] }
 schemars = { package = "apistos-schemars", version = "0.8" }


### PR DESCRIPTION
Addressed issues where old API keys remained active after regeneration.