### PR TITLE
Fix rendering issues in milestone graphs with clustered task dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,7 +799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
 dependencies = [
  "crossbeam-utils",
-] npm9Phj6cF
+]
 
 [[package]]
 name = "crossbeam-utils"


### PR DESCRIPTION
Addressed problems where dense clusters of dependencies caused milestone graphs to misalign.